### PR TITLE
Add support for encoding command-line arguments

### DIFF
--- a/tools/urlencode.py
+++ b/tools/urlencode.py
@@ -4,8 +4,13 @@ try:
     from urllib.parse import quote_plus
 except ImportError:
     from urllib import quote_plus
-data = sys.stdin.readlines()
-dat = ""
-for line in data:
-    dat += line
-print (quote_plus(str(dat)))
+
+if len(sys.argv) > 1:
+    for arg in sys.argv[1:]:
+        print (quote_plus(arg))
+else:
+    data = sys.stdin.readlines()
+    dat = ""
+    for line in data:
+        dat += line
+    print (quote_plus(str(dat)))


### PR DESCRIPTION
Motivation:

The documentation (README.md) shows invocations of `urlencode.py` to build URLs like:

```
https://alise.data.kit.edu/api/v1/target/vega-kc/mapping/issuer/`urlencode.py <issuer>`/user/`urlencode.py <subject>`?apikey=<apikey>
```

In this example, the command `urlencode.py` is given the string to encode as a command-line argument.

Unfortunately, `urlencode.py` currently doesn't support command-line arguments, so this form of invocation does not work.

Modification:

Add support for encoding command-line arguments, if present.

The current behaviour (encoding lines from stdin) is preserved if `urlencode.py` is invoked with no command-line arguments.

Results:

The docuemented behaviour now works.